### PR TITLE
Use env var for Flask secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 **1. System installieren**
 ```bash
 sudo bash install.sh
+```
+
+**2. Anwendung starten**
+Setzen Sie vor dem Start die Umgebungsvariable `FLASK_SECRET_KEY`:
+
+```bash
+export FLASK_SECRET_KEY="ein_sicherer_schluessel"
+python3 app.py
+```

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ import logging
 import re
 
 app = Flask(__name__)
-app.secret_key = 'super_secret_key'  # Bitte in Produktion anpassen!
+app.secret_key = os.environ.get("FLASK_SECRET_KEY")
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 


### PR DESCRIPTION
## Summary
- load Flask secret key from `FLASK_SECRET_KEY` environment variable
- document environment variable usage in deployment instructions

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687dffdd70c88330a7bda89aad392a87