### PR TITLE
Fix README installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 **1. System installieren**
 ```bash
 sudo bash install.sh
+```
+
+**2. Anwendung starten**
+```bash
+python3 app.py
+```
+
+Rufe anschließend im Browser `http://<Pi-IP>:5000` auf und melde dich mit deinem Benutzer an.


### PR DESCRIPTION
## Summary
- close the installation code block in README
- add a small usage section showing how to start the app and open the UI

## Testing
- `tail -c1 README.md | od -An -t x1`

------
https://chatgpt.com/codex/tasks/task_e_687dffd2748c833096a7289563558fe6