### PR TITLE
Add systemd service with start delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ Setzen Sie vor dem Start die Umgebungsvariable `FLASK_SECRET_KEY`:
 export FLASK_SECRET_KEY="ein_sicherer_schluessel"
 python3 app.py
 ```
+
+### Automatischer Start (systemd)
+
+Die Beispieldatei `audio-pi.service` ermöglicht den automatischen Start als systemd-Dienst. 
+Durch die Zeile `ExecStartPre=/bin/sleep 10` wartet der Dienst nach dem Booten zehn Sekunden, bevor `app.py` ausgeführt wird.
+
+Zum Aktivieren kopieren Sie die Datei z.B. nach `/etc/systemd/system/` und laden die Unit neu:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now audio-pi.service
+```

--- a/audio-pi.service
+++ b/audio-pi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Audio Pi Websystem
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/Audio-Pi-Websystem
+ExecStartPre=/bin/sleep 10
+ExecStart=/usr/bin/python3 /opt/Audio-Pi-Websystem/app.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an example `audio-pi.service` unit with `ExecStartPre=/bin/sleep 10`
- document the new service and the 10 s delay in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e04f3e0c08330a6fcc68408a7a6f9