### PR TITLE
Improve secret key init

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,11 +13,16 @@ import lgpio as GPIO
 import pygame
 from pydub import AudioSegment
 import smbus
+import secrets
 import logging
 import re
 
 app = Flask(__name__)
-app.secret_key = os.environ.get("FLASK_SECRET_KEY")
+secret_key = os.environ.get("FLASK_SECRET_KEY")
+if secret_key is None:
+    secret_key = secrets.token_urlsafe(32)
+    logging.warning("FLASK_SECRET_KEY nicht gesetzt, verwende zufälligen Schlüssel")
+app.secret_key = secret_key
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 


### PR DESCRIPTION
## Summary
- generate random key when `FLASK_SECRET_KEY` env variable is missing
- log a warning so users know a temporary key is being used

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687e11bc4014833090e68fd15a0eef8a