### PR TITLE
Set Flask debug via env var

### DIFF
--- a/app.py
+++ b/app.py
@@ -661,4 +661,5 @@ threading.Thread(target=bluetooth_auto_accept, daemon=True).start()
 
 if __name__ == '__main__':
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-    app.run(host='0.0.0.0', port=8080, debug=True)
+    debug_mode = os.environ.get('FLASK_DEBUG', '0') == '1'
+    app.run(host='0.0.0.0', port=8080, debug=debug_mode)

--- a/audio-pi.service
+++ b/audio-pi.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 WorkingDirectory=/opt/Audio-Pi-Websystem
 ExecStartPre=/bin/sleep 10
+Environment=FLASK_DEBUG=0
 ExecStart=/usr/bin/python3 /opt/Audio-Pi-Websystem/app.py
 Restart=on-failure
 


### PR DESCRIPTION
## Summary
- disable Flask debug mode by default
- allow debug mode via FLASK_DEBUG env variable
- ensure systemd unit sets FLASK_DEBUG=0

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687e11badb1483309050cfcc0401398a