### PR TITLE
Fix schedule playback after boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 - **Protokollierung & Logs**
 - **Passwort-Management**
 - **Alle Daten in SQLite-DB**
+- Einmalige Zeitpläne, deren Zeitpunkt bereits vergangen ist, werden beim Start automatisch übersprungen.
 
 ---
 


### PR DESCRIPTION
## Summary
- skip outdated one-time schedules to prevent unexpected playback
- document this behaviour in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e19eb7f508330b8ef922bad8e4167