### PR TITLE
Fix stop_playback

### DIFF
--- a/app.py
+++ b/app.py
@@ -496,7 +496,6 @@ def toggle_pause():
 @app.route('/stop_playback')
 @login_required
 def stop_playback():
-    global amplifier_active_for_bt
     pygame.mixer.music.stop()
     if not is_bt_connected():
         deactivate_amplifier()


### PR DESCRIPTION
## Summary
- remove leftover global from `stop_playback`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4b0614808330a26f1e3fb2cb6327