### PR TITLE
Fix quoting in usermod command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ fi
 
 # PulseAudio Setup für Pi (z.B. HiFiBerry DAC)
 sudo apt install -y pulseaudio pulseaudio-utils
-sudo usermod -aG pulse,pulse-access,audio $USER
+sudo usermod -aG pulse,pulse-access,audio "$USER"
 
 # Bluetooth Audio Setup – Nur SINK (kein Agent)
 sudo apt install -y pulseaudio-module-bluetooth bluez-tools bluez


### PR DESCRIPTION
## Summary
- quote `$USER` in install script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5ccda58883308746433f8e140e09