### PR TITLE
Enforce FLASK_SECRET_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ sudo bash install.sh
 ```
 
 **2. Anwendung starten**
-Setzen Sie vor dem Start die Umgebungsvariable `FLASK_SECRET_KEY`:
+Die Anwendung bricht sofort ab, wenn `FLASK_SECRET_KEY` nicht gesetzt ist.
+Setzen Sie die Umgebungsvariable vor dem Start:
 
 ```bash
 export FLASK_SECRET_KEY="ein_sicherer_schluessel"

--- a/app.py
+++ b/app.py
@@ -20,15 +20,15 @@ import lgpio as GPIO
 import pygame
 from pydub import AudioSegment
 import smbus
-import secrets
+import sys
 import logging
 import re
 
 app = Flask(__name__)
 secret_key = os.environ.get("FLASK_SECRET_KEY")
-if secret_key is None:
-    secret_key = secrets.token_urlsafe(32)
-    logging.warning("FLASK_SECRET_KEY nicht gesetzt, verwende zufälligen Schlüssel")
+if not secret_key:
+    logging.error("FLASK_SECRET_KEY nicht gesetzt. Bitte Umgebungsvariable setzen.")
+    sys.exit(1)
 app.secret_key = secret_key
 login_manager = LoginManager(app)
 login_manager.login_view = "login"


### PR DESCRIPTION
## Summary
- stop generating a random secret key when `FLASK_SECRET_KEY` is missing
- explain in README that the app exits if the variable is not set

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5d09359883308a97173f2777ee4f