### PR TITLE
Fix bluetooth status field in index

### DIFF
--- a/app.py
+++ b/app.py
@@ -520,6 +520,7 @@ def index():
     )
     status = {
         "playing": pygame.mixer.music.get_busy(),
+        "bluetooth_status": "Verbunden" if is_bt_connected() else "Nicht verbunden",
         "wlan_status": wlan_ssid,
         "current_sink": get_current_sink(),
         "current_time": current_time,


### PR DESCRIPTION
## Summary
- include Bluetooth connection state in the status dict

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f3cc17cb883309f38a1213f6cf7af