### PR TITLE
Fix schedule_job when schedule missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,13 +302,19 @@ def run_scheduler():
 def schedule_job(schedule_id):
     cursor.execute("SELECT * FROM schedules WHERE id=?", (schedule_id,))
     sch = cursor.fetchone()
+    if sch is None:
+        logging.warning(f"Schedule {schedule_id} nicht gefunden")
+        return
     item_id = sch[1]
     item_type = sch[2]
     delay = sch[5]
     repeat = sch[4]
     play_item(item_id, item_type, delay, is_schedule=True)
     if repeat == "once":
-        cursor.execute("UPDATE schedules SET executed=1 WHERE id=?", (schedule_id,))
+        cursor.execute(
+            "UPDATE schedules SET executed=1 WHERE id=?",
+            (schedule_id,),
+        )
         conn.commit()
         load_schedules()
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -119,6 +119,15 @@ class ScheduleOnceTests(unittest.TestCase):
         app.cursor.execute("SELECT executed FROM schedules WHERE id=?", (sch_id,))
         self.assertEqual(app.cursor.fetchone()[0], 1)
 
+    def test_schedule_job_missing_schedule(self):
+        with patch.object(app, "play_item") as play_mock, patch.object(
+            app.logging,
+            "warning",
+        ) as warn_mock:
+            app.schedule_job(9999)
+            play_mock.assert_not_called()
+            warn_mock.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid TypeError in `schedule_job` when a schedule id doesn't exist
- add regression test for missing schedule

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f3ea1c15883308f4b833deb8eb30d