### PR TITLE
Add freezegun dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ sudo systemctl enable --now audio-pi.service
 ## Datenbank-Initialisierung
 
 Bei der ersten Ausführung legt die Anwendung automatisch die SQLite-Datenbank `audio.db` an und erzeugt die benötigten Tabellen sowie einen Standard-Benutzer (`admin` / `password`). Es ist daher nicht notwendig, eine vorgefüllte Datenbank mitzuliefern. Wenn `audio.db` nicht existiert, wird sie beim Start erstellt.
+
+## Tests
+
+F\xC3\xBCr die Unittests wird ein separates Requirements-File bereitgestellt. Installieren Sie die Abh\xC3\xA4ngigkeiten vor dem Ausf\xC3\xBChren der Tests:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Die Tests lassen sich danach mit `pytest` starten.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+freezegun
+pytest


### PR DESCRIPTION
## Summary
- add new `requirements-dev.txt` with freezegun and pytest
- document how to install dev requirements to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3e99fc64833081ef06ec0f61392d