### PR TITLE
Fix delete() missing file handling and add test

### DIFF
--- a/app.py
+++ b/app.py
@@ -563,8 +563,14 @@ def upload():
 @login_required
 def delete(file_id):
     cursor.execute("SELECT filename FROM audio_files WHERE id=?", (file_id,))
-    filename = cursor.fetchone()[0]
-    os.remove(os.path.join(app.config["UPLOAD_FOLDER"], filename))
+    row = cursor.fetchone()
+    if not row:
+        flash("Datei nicht gefunden")
+        return redirect(url_for("index"))
+    filename = row[0]
+    file_path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
+    if os.path.exists(file_path):
+        os.remove(file_path)
     cursor.execute("DELETE FROM audio_files WHERE id=?", (file_id,))
     cursor.execute("DELETE FROM playlist_files WHERE file_id=?", (file_id,))
     cursor.execute(

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import sqlite3
+import types
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Fake modules required for app import
+sys.modules["lgpio"] = types.SimpleNamespace(
+    gpiochip_open=lambda *a, **k: 1,
+    gpio_claim_output=lambda *a, **k: None,
+    gpio_write=lambda *a, **k: None,
+    gpio_free=lambda *a, **k: None,
+    error=Exception,
+)
+
+sys.modules["pygame"] = types.SimpleNamespace(
+    mixer=types.SimpleNamespace(
+        init=lambda *a, **k: None,
+        music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+    )
+)
+
+sys.modules["pydub"] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+
+sys.modules["smbus"] = types.SimpleNamespace(
+    SMBus=lambda *a, **k: types.SimpleNamespace(
+        read_i2c_block_data=lambda *a, **k: [0] * 7,
+        write_i2c_block_data=lambda *a, **k: None,
+    )
+)
+
+sys.modules["schedule"] = types.SimpleNamespace(
+    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+    run_pending=lambda *a, **k: None,
+    clear=lambda *a, **k: None,
+)
+
+os.environ["FLASK_SECRET_KEY"] = "test"
+
+# Use in-memory SQLite during tests
+_original_connect = sqlite3.connect
+
+def connect_memory(*args, **kwargs):
+    return _original_connect(":memory:", check_same_thread=False)
+
+
+def dummy_popen(*args, **kwargs):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "")
+    return mock_proc
+
+
+with patch("sqlite3.connect", side_effect=connect_memory), patch(
+    "subprocess.getoutput", return_value="volume: 50%"
+), patch("subprocess.call"), patch("subprocess.Popen", dummy_popen):
+    import app
+    importlib.reload(app)
+
+
+class DeleteTests(unittest.TestCase):
+    def setUp(self):
+        app.cursor.execute("DELETE FROM audio_files")
+        app.conn.commit()
+
+    def test_delete_missing_file(self):
+        with patch("app.flash") as flash_mock, patch("app.redirect") as red_mock, patch(
+            "app.url_for", return_value="/"
+        ), patch("flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()):
+            with app.app.test_request_context("/delete/123"):
+                app.delete(123)
+
+        flash_mock.assert_called_with("Datei nicht gefunden")
+        red_mock.assert_called_with("/")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle nonexistent file IDs in `delete` route
- only remove uploaded file if it exists
- test deleting a nonexistent file

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f474e7f8c83308120846d887c1e3c