### PR TITLE
Add TESTING env guard for hardware setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ if not secret_key:
     logging.error("FLASK_SECRET_KEY nicht gesetzt. Bitte Umgebungsvariable setzen.")
     sys.exit(1)
 app.secret_key = secret_key
+TESTING = os.getenv("TESTING")
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 
@@ -48,30 +49,34 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
-gpio_handle = GPIO.gpiochip_open(4)  # Pi 5 = Chip 4
-logging.info("GPIO initialisiert für Verstärker (OUTPUT/HIGH = an, LOW = aus)")
+if not TESTING:
+    gpio_handle = GPIO.gpiochip_open(4)  # Pi 5 = Chip 4
+    logging.info("GPIO initialisiert für Verstärker (OUTPUT/HIGH = an, LOW = aus)")
+else:
+    gpio_handle = None
 amplifier_claimed = False
 
 # Track pause status manually since pygame lacks a get_paused() helper
 is_paused = False
 
-# Pygame Audio
-pygame.mixer.init()
+# Pygame Audio und Lautstärke nur initialisieren, wenn nicht im Test
+if not TESTING:
+    pygame.mixer.init()
 
 
-def load_initial_volume():
-    output = subprocess.getoutput("pactl get-sink-volume @DEFAULT_SINK@")
-    match = re.search(r"(\d+)%", output)
-    if match:
-        initial_vol = int(match.group(1))
-        pygame.mixer.music.set_volume(initial_vol / 100.0)
-        logging.info(f"Initiale Lautstärke geladen: {initial_vol}%")
+    def load_initial_volume():
+        output = subprocess.getoutput("pactl get-sink-volume @DEFAULT_SINK@")
+        match = re.search(r"(\d+)%", output)
+        if match:
+            initial_vol = int(match.group(1))
+            pygame.mixer.music.set_volume(initial_vol / 100.0)
+            logging.info(f"Initiale Lautstärke geladen: {initial_vol}%")
 
 
-load_initial_volume()
+    load_initial_volume()
 
 # RTC (Echtzeituhr) Setup
-bus = smbus.SMBus(1)
+bus = smbus.SMBus(1) if not TESTING else None
 RTC_ADDRESS = 0x51
 
 
@@ -119,7 +124,8 @@ def sync_rtc_to_system():
         logging.warning("Ungültige RTC-Zeit, überspringe Sync. /set_time nutzen!")
 
 
-sync_rtc_to_system()
+if not TESTING:
+    sync_rtc_to_system()
 
 # DB Setup
 conn = sqlite3.connect(DB_FILE, check_same_thread=False)
@@ -223,7 +229,8 @@ def deactivate_amplifier():
 
 
 # Endstufe beim Start aus
-deactivate_amplifier()
+if not TESTING:
+    deactivate_amplifier()
 
 play_lock = threading.Lock()
 
@@ -362,10 +369,10 @@ def load_schedules():
             )
 
 
-skip_past_once_schedules()
-load_schedules()
-
-threading.Thread(target=run_scheduler, daemon=True).start()
+if not TESTING:
+    skip_past_once_schedules()
+    load_schedules()
+    threading.Thread(target=run_scheduler, daemon=True).start()
 
 
 # --- Bluetooth-Hilfsfunktionen ---
@@ -887,7 +894,8 @@ def bluetooth_auto_accept():
     logging.info(f"Bluetooth auto-accept setup: {stdout} {stderr}")
 
 
-threading.Thread(target=bluetooth_auto_accept, daemon=True).start()
+if not TESTING:
+    threading.Thread(target=bluetooth_auto_accept, daemon=True).start()
 
 if __name__ == "__main__":
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -40,6 +40,7 @@ sys.modules["schedule"] = types.SimpleNamespace(
 )
 
 os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
 
 # Use in-memory SQLite during tests
 _original_connect = sqlite3.connect

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -54,6 +54,7 @@ sys.modules["schedule"] = types.SimpleNamespace(
 )
 
 os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
 
 # Use in-memory SQLite during tests
 original_connect = sqlite3.connect

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -40,6 +40,7 @@ sys.modules["schedule"] = types.SimpleNamespace(
 )
 
 os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
 
 # Use in-memory SQLite during tests
 _original_connect = sqlite3.connect

--- a/tests/test_wlan.py
+++ b/tests/test_wlan.py
@@ -39,6 +39,7 @@ sys.modules["schedule"] = types.SimpleNamespace(
 )
 
 os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
 
 
 def dummy_popen(*args, **kwargs):


### PR DESCRIPTION
## Summary
- wrap GPIO, audio init, RTC sync and threads behind a `TESTING` environment flag
- set `TESTING=1` in tests so hardware setup is skipped

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4dc47a188330a20e2973535b276c