### PR TITLE
Fix upload dir creation when imported

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ login_manager.login_view = "login"
 UPLOAD_FOLDER = "uploads"
 ALLOWED_EXTENSIONS = {"wav", "mp3"}
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 DB_FILE = "audio.db"
 GPIO_PIN_ENDSTUFE = 17
 VERZOEGERUNG_SEC = 5


### PR DESCRIPTION
## Summary
- ensure uploads folder exists on module import

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4db4831c8330b29ec34da2ed4e28