### PR TITLE
Fix startup NameError

### DIFF
--- a/app.py
+++ b/app.py
@@ -897,5 +897,4 @@ if not TESTING:
 
 if __name__ == "__main__":
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-    startup()
     app.run(host="0.0.0.0", port=8080, debug=True)


### PR DESCRIPTION
## Summary
- delete obsolete `startup()` call from `app.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f535f23c88330bab6be6c38f6cfa7