### PR TITLE
Update quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ sudo bash install.sh
 ```
 
 **2. Anwendung starten**
-Die Anwendung bricht sofort ab, wenn `FLASK_SECRET_KEY` nicht gesetzt ist.
-Setzen Sie die Umgebungsvariable vor dem Start:
+Die Anwendung bricht sofort ab, wenn `FLASK_SECRET_KEY` nicht gesetzt ist. Nach
+dem Setzen der Variable genügt ein einfacher Aufruf. Seit dem behobenen
+Startproblem laufen Scheduler, Bluetooth-Monitor und Co. automatisch an – es
+ist kein zusätzlicher Funktionsaufruf mehr nötig.
 
 ```bash
 export FLASK_SECRET_KEY="ein_sicherer_schluessel"


### PR DESCRIPTION
## Summary
- clarify startup steps in the Quickstart section
- note that `python3 app.py` runs without extra calls after the fix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5357acb48330bb3806c70fce7c93