### PR TITLE
Add validation for password change

### DIFF
--- a/app.py
+++ b/app.py
@@ -828,6 +828,9 @@ def change_password():
     if request.method == "POST":
         old_pass = request.form["old_password"]
         new_pass = request.form["new_password"]
+        if not new_pass or len(new_pass) < 4:
+            flash("Neues Passwort zu kurz")
+            return render_template("change_password.html")
         cursor.execute("SELECT password FROM users WHERE id=?", (current_user.id,))
         hashed = cursor.fetchone()[0]
         if check_password_hash(hashed, old_pass):


### PR DESCRIPTION
## Summary
- prevent empty passwords in `change_password`
- test empty password submission

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f572c6f30833084d631a5e660a029