### PR TITLE
Use POST for state-changing routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,11 @@ Dieses Repository verwandelt den Raspberry Pi in ein lokales Steuer- und Audiosy
 | /login, /logout                  | GET/POST| Login, Logout                   | ✖            |
 | /upload                          | POST    | Audiodatei hochladen            | ✔            |
 | /play_now/<typ>/<id>             | GET     | Datei/Playlist sofort abspielen | ✔            |
-| /schedule, /delete_schedule      | POST/GET| Zeitplan setzen/löschen         | ✔            |
+| /schedule, /delete_schedule      | POST    | Zeitplan setzen/löschen         | ✔            |
 | /create_playlist, /add_to_playlist | POST  | Playlists verwalten             | ✔            |
-| /delete_playlist/<id>            | GET     | Playlist löschen                | ✔            |
-| /toggle_pause, /stop_playback    | GET     | Wiedergabe steuern              | ✔            |
-| /activate_amp, /deactivate_amp   | GET     | Endstufe schalten               | ✔            |
+| /delete_playlist/<id>            | POST    | Playlist löschen                | ✔            |
+| /toggle_pause, /stop_playback    | POST    | Wiedergabe steuern              | ✔            |
+| /activate_amp, /deactivate_amp   | POST    | Endstufe schalten               | ✔            |
 | /volume                          | POST    | Lautstärke setzen               | ✔            |
 | /logs                            | GET     | Logfile anzeigen                | ✔            |
 | /wlan_scan, /wlan_connect        | GET/POST| WLAN-Management                 | ✔            |

--- a/app.py
+++ b/app.py
@@ -561,7 +561,7 @@ def upload():
     return redirect(url_for("index"))
 
 
-@app.route("/delete/<int:file_id>")
+@app.route("/delete/<int:file_id>", methods=["POST"])
 @login_required
 def delete(file_id):
     cursor.execute("SELECT filename FROM audio_files WHERE id=?", (file_id,))
@@ -607,7 +607,7 @@ def add_to_playlist():
     return redirect(url_for("index"))
 
 
-@app.route("/delete_playlist/<int:playlist_id>")
+@app.route("/delete_playlist/<int:playlist_id>", methods=["POST"])
 @login_required
 def delete_playlist(playlist_id):
     cursor.execute("DELETE FROM playlists WHERE id=?", (playlist_id,))
@@ -629,7 +629,7 @@ def play_now(item_type, item_id):
     return redirect(url_for("index"))
 
 
-@app.route("/toggle_pause")
+@app.route("/toggle_pause", methods=["POST"])
 @login_required
 def toggle_pause():
     global is_paused
@@ -645,7 +645,7 @@ def toggle_pause():
     return redirect(url_for("index"))
 
 
-@app.route("/stop_playback")
+@app.route("/stop_playback", methods=["POST"])
 @login_required
 def stop_playback():
     pygame.mixer.music.stop()
@@ -661,7 +661,7 @@ def stop_playback():
     return redirect(url_for("index"))
 
 
-@app.route("/activate_amp")
+@app.route("/activate_amp", methods=["POST"])
 @login_required
 def activate_amp():
     try:
@@ -672,7 +672,7 @@ def activate_amp():
     return redirect(url_for("index"))
 
 
-@app.route("/deactivate_amp")
+@app.route("/deactivate_amp", methods=["POST"])
 @login_required
 def deactivate_amp():
     try:
@@ -722,7 +722,7 @@ def add_schedule():
     return redirect(url_for("index"))
 
 
-@app.route("/delete_schedule/<int:sch_id>")
+@app.route("/delete_schedule/<int:sch_id>", methods=["POST"])
 @login_required
 def delete_schedule(sch_id):
     cursor.execute("DELETE FROM schedules WHERE id=?", (sch_id,))

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,16 +25,16 @@
         <input type="number" min="0" max="100" name="volume" placeholder="Lautstärke (%)">
         <button type="submit">Setzen</button>
     </form>
-    <form action="{{ url_for('activate_amp') }}" method="GET" style="display:inline;">
+    <form action="{{ url_for('activate_amp') }}" method="POST" style="display:inline;">
         <button type="submit">Endstufe an</button>
     </form>
-    <form action="{{ url_for('deactivate_amp') }}" method="GET" style="display:inline;">
+    <form action="{{ url_for('deactivate_amp') }}" method="POST" style="display:inline;">
         <button type="submit">Endstufe aus</button>
     </form>
-    <form action="{{ url_for('toggle_pause') }}" method="GET" style="display:inline;">
+    <form action="{{ url_for('toggle_pause') }}" method="POST" style="display:inline;">
         <button type="submit">Pause/Resume</button>
     </form>
-    <form action="{{ url_for('stop_playback') }}" method="GET" style="display:inline;">
+    <form action="{{ url_for('stop_playback') }}" method="POST" style="display:inline;">
         <button type="submit">Stopp</button>
     </form>
     <hr>
@@ -50,7 +50,9 @@
         <li>
             {{ file[1] }}
             <a href="{{ url_for('play_now', item_type='file', item_id=file[0]) }}">Play</a>
-            <a href="{{ url_for('delete', file_id=file[0]) }}">Löschen</a>
+            <form action="{{ url_for('delete', file_id=file[0]) }}" method="POST" style="display:inline;">
+                <button type="submit">Löschen</button>
+            </form>
         </li>
         {% endfor %}
     </ul>
@@ -65,7 +67,9 @@
         <li>
             {{ playlist[1] }}
             <a href="{{ url_for('play_now', item_type='playlist', item_id=playlist[0]) }}">Play</a>
-            <a href="{{ url_for('delete_playlist', playlist_id=playlist[0]) }}">Löschen</a>
+            <form action="{{ url_for('delete_playlist', playlist_id=playlist[0]) }}" method="POST" style="display:inline;">
+                <button type="submit">Löschen</button>
+            </form>
             <form action="{{ url_for('add_to_playlist') }}" method="POST" style="display:inline;">
                 <select name="file_id">
                     {% for file in files %}
@@ -111,7 +115,9 @@
         <li>
             {{ schedule[1] }} ({{ schedule[5] }}) - {{ schedule[2] }} ({{ schedule[3] }}) +{{ schedule[4] }}s
             {% if schedule[6] and schedule[3] == 'once' %}- ausgeführt{% endif %}
-            <a href="{{ url_for('delete_schedule', sch_id=schedule[0]) }}">Entfernen</a>
+            <form action="{{ url_for('delete_schedule', sch_id=schedule[0]) }}" method="POST" style="display:inline;">
+                <button type="submit">Entfernen</button>
+            </form>
         </li>
         {% endfor %}
     </ul>

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -71,7 +71,7 @@ class DeleteTests(unittest.TestCase):
         with patch("app.flash") as flash_mock, patch("app.redirect") as red_mock, patch(
             "app.url_for", return_value="/"
         ), patch("flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()):
-            with app.app.test_request_context("/delete/123"):
+            with app.app.test_request_context("/delete/123", method="POST"):
                 app.delete(123)
 
         flash_mock.assert_called_with("Datei nicht gefunden")


### PR DESCRIPTION
## Summary
- enforce POST on delete and amplifier routes
- update forms in templates to submit via POST
- adjust docs to match new route methods
- modify tests to send POST requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f573957a083309af6b297f8db94a0