### PR TITLE
Improve RTC error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,16 @@ if not TESTING:
     load_initial_volume()
 
 # RTC (Echtzeituhr) Setup
-bus = smbus.SMBus(1) if not TESTING else None
+class RTCUnavailableError(Exception):
+    """RTC I²C-Bus konnte nicht initialisiert werden."""
+
+
+try:
+    bus = smbus.SMBus(1) if not TESTING else None
+except (FileNotFoundError, OSError) as e:
+    logging.warning(f"RTC SMBus nicht verfügbar: {e}")
+    bus = None
+
 RTC_ADDRESS = 0x51
 
 
@@ -98,6 +107,8 @@ def dec_to_bcd(val):
 
 
 def read_rtc():
+    if bus is None:
+        raise RTCUnavailableError("RTC-Bus nicht initialisiert")
     data = bus.read_i2c_block_data(RTC_ADDRESS, 0x04, 7)
     second = bcd_to_dec(data[0] & 0x7F)
     minute = bcd_to_dec(data[1] & 0x7F)
@@ -111,6 +122,8 @@ def read_rtc():
 
 
 def set_rtc(dt):
+    if bus is None:
+        raise RTCUnavailableError("RTC-Bus nicht initialisiert")
     second = dec_to_bcd(dt.second)
     minute = dec_to_bcd(dt.minute)
     hour = dec_to_bcd(dt.hour)
@@ -129,8 +142,8 @@ def sync_rtc_to_system():
         rtc_time = read_rtc()
         subprocess.call(["sudo", "date", "-s", rtc_time.strftime("%Y-%m-%d %H:%M:%S")])
         logging.info("RTC auf Systemzeit synchronisiert")
-    except ValueError:
-        logging.warning("Ungültige RTC-Zeit, überspringe Sync. /set_time nutzen!")
+    except (ValueError, OSError, RTCUnavailableError) as e:
+        logging.warning(f"RTC-Sync übersprungen: {e}")
 
 
 if not TESTING:

--- a/tests/test_rtc_missing.py
+++ b/tests/test_rtc_missing.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import subprocess
+import textwrap
+import unittest
+
+class RtcMissingTests(unittest.TestCase):
+    def test_app_import_without_rtc(self):
+        root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        script = textwrap.dedent(
+            f"""
+            import os, sys, types
+            os.environ['FLASK_SECRET_KEY'] = 'test'
+            sys.path.insert(0, r'{root}')
+            sys.modules['lgpio'] = types.SimpleNamespace(
+                gpiochip_open=lambda *a, **k: 1,
+                gpio_claim_output=lambda *a, **k: None,
+                gpio_write=lambda *a, **k: None,
+                gpio_free=lambda *a, **k: None,
+                error=Exception,
+            )
+            sys.modules['pygame'] = types.SimpleNamespace(
+                mixer=types.SimpleNamespace(
+                    init=lambda *a, **k: None,
+                    music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+                )
+            )
+            sys.modules['pydub'] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+            sys.modules['schedule'] = types.SimpleNamespace(
+                every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+                run_pending=lambda *a, **k: None,
+                clear=lambda *a, **k: None,
+            )
+            def raise_fnf(*a, **k):
+                raise FileNotFoundError('missing bus')
+            sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)
+            started = []
+            class DummyThread:
+                def __init__(self, *a, **k):
+                    self.started = False
+                def start(self):
+                    self.started = True
+                    started.append(True)
+            import threading
+            threading.Thread = lambda *a, **k: DummyThread()
+            import app
+            print('started', bool(started))
+            print('bus_is_none', app.bus is None)
+            """
+        )
+        env = os.environ.copy()
+        env.pop("TESTING", None)
+        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, env=env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('started True', result.stdout)
+        self.assertIn('bus_is_none True', result.stdout)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle RTC initialization errors
- guard RTC access when bus isn't available
- skip RTC sync if invalid or missing
- test behavior when RTC bus is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5d201a2c8330b8df83d4be295494