### PR TITLE
Make Flask debug mode configurable

### DIFF
--- a/app.py
+++ b/app.py
@@ -947,4 +947,5 @@ if not TESTING:
 
 if __name__ == "__main__":
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-    app.run(host="0.0.0.0", port=8080, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in ("1", "true", "yes")
+    app.run(host="0.0.0.0", port=8080, debug=debug)


### PR DESCRIPTION
## Summary
- allow disabling Flask debug mode by environment variable `FLASK_DEBUG`

## Testing
- `ruff check app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f63fef2b08330a9da2f6f84530b36