### PR TITLE
Add schedule id validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -758,6 +758,10 @@ def add_schedule():
         flash("Ungültiger Typ ausgewählt")
         return redirect(url_for("index"))
 
+    if not item_id:
+        flash("Kein Element gewählt")
+        return redirect(url_for("index"))
+
     cursor.execute(
         "INSERT INTO schedules (item_id, item_type, time, repeat, delay, executed) VALUES (?, ?, ?, ?, ?, 0)",
         (item_id, item_type, time_only, repeat, delay),

--- a/tests/test_schedule_validation.py
+++ b/tests/test_schedule_validation.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import sqlite3
+import types
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Fake modules required for app import
+sys.modules["lgpio"] = types.SimpleNamespace(
+    gpiochip_open=lambda *a, **k: 1,
+    gpio_claim_output=lambda *a, **k: None,
+    gpio_write=lambda *a, **k: None,
+    gpio_free=lambda *a, **k: None,
+    error=Exception,
+)
+
+sys.modules["pygame"] = types.SimpleNamespace(
+    mixer=types.SimpleNamespace(
+        init=lambda *a, **k: None,
+        music=types.SimpleNamespace(
+            set_volume=lambda *a, **k: None,
+            load=lambda *a, **k: None,
+            play=lambda *a, **k: None,
+            get_busy=lambda *a, **k: False,
+        ),
+    )
+)
+
+sys.modules["pydub"] = types.SimpleNamespace(
+    AudioSegment=types.SimpleNamespace(
+        from_file=lambda *a, **k: types.SimpleNamespace(
+            normalize=lambda *a, **k: types.SimpleNamespace(export=lambda *a, **k: None)
+        )
+    )
+)
+
+sys.modules["smbus"] = types.SimpleNamespace(
+    SMBus=lambda *a, **k: types.SimpleNamespace(
+        read_i2c_block_data=lambda *a, **k: [0] * 7,
+        write_i2c_block_data=lambda *a, **k: None,
+    )
+)
+
+sys.modules["schedule"] = types.SimpleNamespace(
+    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+    run_pending=lambda *a, **k: None,
+    clear=lambda *a, **k: None,
+)
+
+os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
+
+# Use in-memory SQLite during tests
+_original_connect = sqlite3.connect
+
+def connect_memory(*args, **kwargs):
+    return _original_connect(":memory:", check_same_thread=False)
+
+
+def dummy_popen(*args, **kwargs):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "")
+    return mock_proc
+
+
+with patch("sqlite3.connect", side_effect=connect_memory), patch(
+    "subprocess.getoutput", return_value="volume: 50%"
+), patch("subprocess.call"), patch("subprocess.Popen", dummy_popen):
+    import app
+    importlib.reload(app)
+
+
+class ScheduleValidationTests(unittest.TestCase):
+    def setUp(self):
+        app.cursor.execute("DELETE FROM schedules")
+        app.conn.commit()
+
+    def test_missing_item_id(self):
+        with patch("app.flash") as flash_mock, patch("app.redirect") as red_mock, patch(
+            "app.url_for", return_value="/"
+        ), patch(
+            "flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()
+        ):
+            with app.app.test_request_context(
+                "/schedule",
+                method="POST",
+                data={
+                    "item_type": "file",
+                    "file_id": "",
+                    "playlist_id": "",
+                    "time": "2024-01-01T10:00",
+                    "repeat": "once",
+                    "delay": "0",
+                },
+            ):
+                app.add_schedule()
+
+        flash_mock.assert_called_with("Kein Element gewählt")
+        red_mock.assert_called_with("/")
+        app.cursor.execute("SELECT COUNT(*) FROM schedules")
+        self.assertEqual(app.cursor.fetchone()[0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `/schedule` route validates selected item id
- add unit test covering missing schedule element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f695ae28c83308b00342224528d38