### PR TITLE
Handle RTC unavailable in set_time route

### DIFF
--- a/app.py
+++ b/app.py
@@ -902,8 +902,8 @@ def set_time():
             subprocess.call(["sudo", "date", "-s", dt.strftime("%Y-%m-%d %H:%M:%S")])
             set_rtc(dt)
             flash("Datum und Uhrzeit gesetzt")
-        except ValueError:
-            flash("Ungültiges Datums-/Zeitformat")
+        except (ValueError, RTCUnavailableError):
+            flash("Ungültiges Datums-/Zeitformat oder RTC nicht verfügbar")
         return redirect(url_for("index"))
     return render_template("set_time.html")
 

--- a/tests/test_set_time_no_rtc.py
+++ b/tests/test_set_time_no_rtc.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import sqlite3
+import types
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Fake modules required for app import
+sys.modules["lgpio"] = types.SimpleNamespace(
+    gpiochip_open=lambda *a, **k: 1,
+    gpio_claim_output=lambda *a, **k: None,
+    gpio_write=lambda *a, **k: None,
+    gpio_free=lambda *a, **k: None,
+    error=Exception,
+)
+
+sys.modules["pygame"] = types.SimpleNamespace(
+    mixer=types.SimpleNamespace(
+        init=lambda *a, **k: None,
+        music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+    )
+)
+
+sys.modules["pydub"] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+
+sys.modules["smbus"] = types.SimpleNamespace(
+    SMBus=lambda *a, **k: types.SimpleNamespace(
+        read_i2c_block_data=lambda *a, **k: [0] * 7,
+        write_i2c_block_data=lambda *a, **k: None,
+    )
+)
+
+sys.modules["schedule"] = types.SimpleNamespace(
+    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+    run_pending=lambda *a, **k: None,
+    clear=lambda *a, **k: None,
+)
+
+os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
+
+# Use in-memory SQLite during tests
+_original_connect = sqlite3.connect
+
+def connect_memory(*args, **kwargs):
+    return _original_connect(":memory:", check_same_thread=False)
+
+
+def dummy_popen(*args, **kwargs):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "")
+    return mock_proc
+
+with patch("sqlite3.connect", side_effect=connect_memory), patch(
+    "subprocess.getoutput", return_value="volume: 50%"
+), patch("subprocess.call"), patch("subprocess.Popen", dummy_popen):
+    import app
+    importlib.reload(app)
+
+
+class SetTimeNoRtcTests(unittest.TestCase):
+    def test_set_time_no_rtc(self):
+        with patch("app.flash") as flash_mock, patch("app.redirect"), patch(
+            "app.url_for", return_value="/"
+        ), patch(
+            "flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()
+        ):
+            with app.app.test_request_context(
+                "/set_time",
+                method="POST",
+                data={"datetime": "2023-01-01T12:00:00"},
+            ):
+                app.bus = None
+                app.set_time()
+        flash_mock.assert_called_with(
+            "Ungültiges Datums-/Zeitformat oder RTC nicht verfügbar"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `/set_time` to handle unavailable RTC
- test posting to `/set_time` when RTC bus is `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f69566c74833095d51a362c3c7390