### PR TITLE
Launch BT monitor

### DIFF
--- a/app.py
+++ b/app.py
@@ -944,6 +944,7 @@ def bluetooth_auto_accept():
 
 if not TESTING:
     threading.Thread(target=bluetooth_auto_accept, daemon=True).start()
+    threading.Thread(target=bt_audio_monitor, daemon=True).start()
 
 if __name__ == "__main__":
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)

--- a/tests/test_bt_monitor_thread.py
+++ b/tests/test_bt_monitor_thread.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import subprocess
+import textwrap
+import unittest
+
+
+class BtMonitorThreadTests(unittest.TestCase):
+    def test_monitor_thread_starts_on_import(self):
+        root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        script = textwrap.dedent(
+            f"""
+            import os, sys, types
+            os.environ['FLASK_SECRET_KEY'] = 'test'
+            sys.path.insert(0, r'{root}')
+            sys.modules['lgpio'] = types.SimpleNamespace(
+                gpiochip_open=lambda *a, **k: 1,
+                gpio_claim_output=lambda *a, **k: None,
+                gpio_write=lambda *a, **k: None,
+                gpio_free=lambda *a, **k: None,
+                error=Exception,
+            )
+            sys.modules['pygame'] = types.SimpleNamespace(
+                mixer=types.SimpleNamespace(
+                    init=lambda *a, **k: None,
+                    music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+                )
+            )
+            sys.modules['pydub'] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+            sys.modules['schedule'] = types.SimpleNamespace(
+                every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+                run_pending=lambda *a, **k: None,
+                clear=lambda *a, **k: None,
+            )
+            def raise_fnf(*a, **k):
+                raise FileNotFoundError('missing bus')
+            sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)
+            started = []
+            class DummyThread:
+                def __init__(self, target=None, *a, **k):
+                    self.target = target
+                def start(self):
+                    started.append(self.target.__name__)
+            import threading
+            threading.Thread = lambda *a, **k: DummyThread(*a, **k)
+            import app
+            print('targets', started)
+            """
+        )
+        env = os.environ.copy()
+        env.pop("TESTING", None)
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, env=env
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('bt_audio_monitor', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- spawn `bt_audio_monitor` alongside auto-accept thread
- verify the monitor thread starts when importing `app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6951cba083308ac7cd855ffe678d