### PR TITLE
Use venv for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 sudo bash install.sh
 ```
 
-**2. Anwendung starten**
+**2. Virtuelle Umgebung aktivieren**
+```bash
+source venv/bin/activate
+```
+**3. Anwendung starten**
 Die Anwendung bricht sofort ab, wenn `FLASK_SECRET_KEY` nicht gesetzt ist. Nach
 dem Setzen der Variable genügt ein einfacher Aufruf. Seit dem behobenen
 Startproblem laufen Scheduler, Bluetooth-Monitor und Co. automatisch an – es
@@ -35,7 +39,7 @@ ist kein zusätzlicher Funktionsaufruf mehr nötig.
 
 ```bash
 export FLASK_SECRET_KEY="ein_sicherer_schluessel"
-python3 app.py
+python app.py
 ```
 
 ### Automatischer Start (systemd)
@@ -55,9 +59,10 @@ Bei der ersten Ausführung legt die Anwendung automatisch die SQLite-Datenbank `
 
 ## Tests
 
-Für die Unittests werden die Abhängigkeiten aus beiden Requirements-Dateien benötigt. Installieren Sie diese vor dem Ausführen der Tests:
+Für die Unittests werden die Abhängigkeiten aus beiden Requirements-Dateien benötigt. Aktivieren Sie zunächst die virtuelle Umgebung und installieren Sie dann die Requirements:
 
 ```bash
+source venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
 pytest

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,16 @@ sudo apt upgrade -y
 # Python-Basics & PIP
 sudo apt install -y python3 python3-pip python3-venv
 
+# Virtuelle Umgebung einrichten
+python3 -m venv venv
+source venv/bin/activate
+
+
 # Dev-Packages (für pydub/pygame etc.)
 sudo apt install -y libasound2-dev libpulse-dev libportaudio2 ffmpeg libffi-dev libjpeg-dev libbluetooth-dev
 
 # Python-Abhängigkeiten installieren
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 
 # I²C für RTC aktivieren
 sudo raspi-config nonint do_i2c 0
@@ -66,7 +71,7 @@ echo "Wenn RTC/I2C/Overlay neu eingerichtet wurden: Bitte RASPBERRY PI NEU START
 
 echo ""
 echo "Setup abgeschlossen! Starte mit:"
-echo "python3 app.py"
+echo "source venv/bin/activate && python app.py"
 echo ""
 echo "Öffne im Browser: http://<RaspberryPi-IP>:8080"
 echo ""


### PR DESCRIPTION
## Summary
- set up a Python virtual environment in `install.sh`
- adjust quickstart instructions in README to use the venv
- document venv usage when running tests

## Testing
- `pytest -q`
- `bash install.sh` *(fails later because raspi-config is missing, but pip installs in venv without errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f9d8abd3c833093cb443792f51bde