### PR TITLE
Implement relay inversion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 - **Audio-Wiedergabe per Zeitplan** (Einzeldateien & Playlists)
 - **Bluetooth als Audio-Sink** (Handy → Pi → Verstärker)
 - **Endstufe/GPIO automatisch schalten** (bei Musik oder BT-Audio)
+- **Relais-Logik invertierbar über Web-UI**
 - **RTC-Steuerung & Systemzeit**
 - **WLAN-Scan, Verbindungsaufbau, AP-Fallback** (SSIDs und Passwörter dürfen Anführungszeichen und Backslashes enthalten)
 - **Web-Interface (Flask, passwortgeschützt)**

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
         <li>Bluetooth: {{ status['bluetooth_status'] }}</li>
         <li>WLAN: {{ status['wlan_status'] }}</li>
         <li>Endstufe: {{ status['amplifier_status'] }}</li>
+        <li>Relais-Umkehr: {{ 'Ja' if status['relay_invert'] else 'Nein' }}</li>
         <li>Lautstärke: {{ status['current_volume'] }}</li>
         <li>Time: {{ status['current_time'] }}</li>
     </ul>
@@ -30,6 +31,13 @@
     </form>
     <form action="{{ url_for('deactivate_amp') }}" method="POST" style="display:inline;">
         <button type="submit">Endstufe aus</button>
+    </form>
+    <form action="{{ url_for('set_relay_invert') }}" method="POST" style="display:inline;">
+        <label>
+            <input type="checkbox" name="invert" value="1" {% if status['relay_invert'] %}checked{% endif %}>
+            Relay umkehren
+        </label>
+        <button type="submit">Speichern</button>
     </form>
     <form action="{{ url_for('toggle_pause') }}" method="POST" style="display:inline;">
         <button type="submit">Pause/Resume</button>

--- a/tests/test_relay_invert.py
+++ b/tests/test_relay_invert.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import sqlite3
+import types
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Fake modules required for app import
+sys.modules["lgpio"] = types.SimpleNamespace(
+    gpiochip_open=lambda *a, **k: 1,
+    gpio_claim_output=lambda *a, **k: None,
+    gpio_write=lambda *a, **k: None,
+    gpio_free=lambda *a, **k: None,
+    error=Exception,
+)
+
+sys.modules["pygame"] = types.SimpleNamespace(
+    mixer=types.SimpleNamespace(
+        init=lambda *a, **k: None,
+        music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+    )
+)
+
+sys.modules["pydub"] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+
+sys.modules["smbus"] = types.SimpleNamespace(
+    SMBus=lambda *a, **k: types.SimpleNamespace(
+        read_i2c_block_data=lambda *a, **k: [0] * 7,
+        write_i2c_block_data=lambda *a, **k: None,
+    )
+)
+
+sys.modules["schedule"] = types.SimpleNamespace(
+    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
+    run_pending=lambda *a, **k: None,
+    clear=lambda *a, **k: None,
+)
+
+os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
+
+# Use in-memory SQLite during tests
+_original_connect = sqlite3.connect
+
+def connect_memory(*args, **kwargs):
+    return _original_connect(":memory:", check_same_thread=False)
+
+
+def dummy_popen(*args, **kwargs):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "")
+    return mock_proc
+
+
+with patch("sqlite3.connect", side_effect=connect_memory), patch(
+    "subprocess.getoutput", return_value="volume: 50%"
+), patch("subprocess.call"), patch("subprocess.Popen", dummy_popen):
+    import app
+    importlib.reload(app)
+
+
+class RelayInvertTests(unittest.TestCase):
+    def setUp(self):
+        app.cursor.execute("DELETE FROM settings")
+        app.conn.commit()
+        app.RELAY_INVERT = False
+        app.update_amp_levels()
+
+    def test_set_relay_invert(self):
+        with patch("app.flash"), patch("app.redirect"), patch(
+            "app.url_for", return_value="/"
+        ), patch(
+            "flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()
+        ):
+            with app.app.test_request_context(
+                "/set_relay_invert", method="POST", data={"invert": "1"}
+            ):
+                app.set_relay_invert()
+        self.assertTrue(app.RELAY_INVERT)
+        app.cursor.execute("SELECT value FROM settings WHERE key='relay_invert'")
+        self.assertEqual(app.cursor.fetchone()[0], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow storing boolean settings in the new `settings` table
- add global relay inversion flag with update logic
- adjust amplifier GPIO handling to respect inversion
- expose inversion checkbox in the web interface
- document new feature in the README
- add regression test for changing the setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff3bc9d8c8330b9241ea4c8f0a8d4