### PR TITLE
Update README install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 ```bash
 sudo bash install.sh
 ```
+Während der Installation fragt das Skript nach einem Wert für `FLASK_SECRET_KEY`
+und richtet den systemd-Dienst direkt ein.
 
 **2. Virtuelle Umgebung aktivieren**
 ```bash
@@ -44,10 +46,13 @@ python app.py
 
 ### Automatischer Start (systemd)
 
-Die Beispieldatei `audio-pi.service` ermöglicht den automatischen Start als systemd-Dienst.
-Durch die Zeile `ExecStartPre=/bin/sleep 10` wartet der Dienst nach dem Booten zehn Sekunden, bevor `app.py` ausgeführt wird.
+`install.sh` kopiert und konfiguriert `audio-pi.service` automatisch. Die
+Service-Datei nutzt den Python-Interpreter aus der virtuellen Umgebung und
+startet das Programm mit PulseAudio-Zugriff (entweder über `User=pi` oder mit
+`PULSE_RUNTIME_PATH`). Durch `ExecStartPre=/bin/sleep 10` wartet der Dienst nach
+dem Booten zehn Sekunden, bevor `app.py` ausgeführt wird.
 
-Zum Aktivieren kopieren Sie die Datei z.B. nach `/etc/systemd/system/` und laden die Unit neu:
+Sollte die Unit manuell neu geladen werden müssen, genügt:
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now audio-pi.service


### PR DESCRIPTION
## Summary
- clarify that `install.sh` asks for a `FLASK_SECRET_KEY` and sets up systemd
- explain that the service runs inside the venv and uses PulseAudio via `User=pi` or `PULSE_RUNTIME_PATH`

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff30513b88330a202ff7940d28d6a