### PR TITLE
Update installer to set FLASK secret

### DIFF
--- a/audio-pi.service
+++ b/audio-pi.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=/opt/Audio-Pi-Websystem
 ExecStartPre=/bin/sleep 10
 Environment=FLASK_DEBUG=0
+Environment=FLASK_SECRET_KEY=
 ExecStart=/usr/bin/python3 /opt/Audio-Pi-Websystem/app.py
 Restart=on-failure
 

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,10 @@ sudo apt install -y libasound2-dev libpulse-dev libportaudio2 ffmpeg libffi-dev 
 # Python-Abhängigkeiten installieren
 pip install -r requirements.txt
 
+# Benutzer nach Secret fragen und in Profil speichern
+read -rp "FLASK_SECRET_KEY: " SECRET
+echo "export FLASK_SECRET_KEY=\"$SECRET\"" >> ~/.profile
+
 # I²C für RTC aktivieren
 sudo raspi-config nonint do_i2c 0
 echo "i2c-dev" | sudo tee -a /etc/modules
@@ -58,6 +62,7 @@ chmod 666 app.log
 # systemd-Dienst einrichten
 sudo cp audio-pi.service /etc/systemd/system/
 sudo sed -i "s|/opt/Audio-Pi-Websystem|$(pwd)|g" /etc/systemd/system/audio-pi.service
+sudo sed -i "s|FLASK_SECRET_KEY=|FLASK_SECRET_KEY=$SECRET|" /etc/systemd/system/audio-pi.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now audio-pi.service
 


### PR DESCRIPTION
## Summary
- prompt for `FLASK_SECRET_KEY` in `install.sh`
- store the value in the user profile
- patch the installed systemd unit with the secret
- add placeholder variable to `audio-pi.service`

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff2f7dae883309d77b346d71519c0