### PR TITLE
Fix systemd service placeholder path

### DIFF
--- a/audio-pi.service
+++ b/audio-pi.service
@@ -4,13 +4,13 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/pi/Audio-Pi-Websystem
+WorkingDirectory=/opt/Audio-Pi-Websystem
 ExecStartPre=/bin/sleep 10
 Environment=FLASK_DEBUG=0
 Environment=FLASK_SECRET_KEY=
 User=pi
 Group=audio
-ExecStart=/home/pi/Audio-Pi-Websystem/venv/bin/python /home/pi/Audio-Pi-Websystem/app.py
+ExecStart=/opt/Audio-Pi-Websystem/venv/bin/python /opt/Audio-Pi-Websystem/app.py
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- adjust `audio-pi.service` to use `/opt/Audio-Pi-Websystem` placeholder
  so `install.sh` replaces it with the actual install path

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff895147c8330a265c327aab13d2f