### PR TITLE
Add APScheduler misfire test

### DIFF
--- a/tests/test_schedule_misfire.py
+++ b/tests/test_schedule_misfire.py
@@ -1,0 +1,30 @@
+import time
+import unittest
+from freezegun import freeze_time
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+
+class ScheduleMisfireTests(unittest.TestCase):
+    def test_daily_misfire_skipped_on_startup(self):
+        executed = []
+
+        def job():
+            executed.append(True)
+
+        with freeze_time("2024-01-01 09:00:00"):
+            scheduler = BackgroundScheduler()
+            scheduler.add_job(
+                job,
+                CronTrigger(hour=8, minute=0),
+                misfire_grace_time=30,
+            )
+            scheduler.start()
+            time.sleep(0.1)
+            scheduler.shutdown(wait=False)
+
+        self.assertEqual(executed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test to ensure APScheduler skips missed jobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff90e4fe4833090a487c1d5f2dcbc