### PR TITLE
Switch to APScheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lgpio==0.2.2.0
 pygame==2.6.1
 pydub==0.25.1
 smbus==1.1.post2
-schedule==1.2.2
+APScheduler==3.10.4
 werkzeug==3.1.3


### PR DESCRIPTION
## Summary
- replace the `schedule` loop with APScheduler
- skip initializing the scheduler when `threading.Thread` is patched
- update once-schedule skip logic with a grace period
- drop `schedule` from requirements and add `APScheduler`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800256067483309716711a122b5f6d