### PR TITLE
Ensure freeze_time advances in schedule misfire test

### DIFF
--- a/tests/test_schedule_misfire.py
+++ b/tests/test_schedule_misfire.py
@@ -12,7 +12,7 @@ class ScheduleMisfireTests(unittest.TestCase):
         def job():
             executed.append(True)
 
-        with freeze_time("2024-01-01 09:00:00"):
+        with freeze_time("2024-01-01 09:00:00", tick=True):
             scheduler = BackgroundScheduler()
             scheduler.add_job(
                 job,


### PR DESCRIPTION
## Summary
- advance the frozen clock by using `tick=True` in `freeze_time`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800b3da41483308eb13f77c020a314