### PR TITLE
Refactor scheduler imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,14 +2,9 @@ import os
 import time
 import subprocess
 import threading
-if isinstance(threading.Thread, type):
-    from apscheduler.schedulers.background import BackgroundScheduler
-    from apscheduler.triggers.cron import CronTrigger
-    from apscheduler.triggers.date import DateTrigger
-else:
-    BackgroundScheduler = None
-    CronTrigger = None
-    DateTrigger = None
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta
@@ -190,7 +185,7 @@ if not cursor.execute("SELECT * FROM users").fetchone():
 conn.commit()
 
 # Scheduler
-scheduler = BackgroundScheduler() if BackgroundScheduler else None
+scheduler = BackgroundScheduler()
 
 
 def get_setting(key, default=None):
@@ -427,8 +422,6 @@ def skip_past_once_schedules():
 
 
 def load_schedules():
-    if scheduler is None:
-        return
     scheduler.remove_all_jobs()
     cursor.execute("SELECT * FROM schedules")
     for sch in cursor.fetchall():
@@ -469,8 +462,7 @@ def load_schedules():
 if not TESTING:
     skip_past_once_schedules()
     load_schedules()
-    if scheduler is not None:
-        scheduler.start()
+    scheduler.start()
 
 
 # --- Bluetooth-Hilfsfunktionen ---
@@ -1019,5 +1011,4 @@ if __name__ == "__main__":
     try:
         app.run(host="0.0.0.0", port=8080, debug=debug)
     finally:
-        if scheduler:
-            scheduler.shutdown()
+        scheduler.shutdown()

--- a/tests/test_bt_monitor_thread.py
+++ b/tests/test_bt_monitor_thread.py
@@ -36,13 +36,17 @@ class BtMonitorThreadTests(unittest.TestCase):
                 raise FileNotFoundError('missing bus')
             sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)
             started = []
-            class DummyThread:
+            import threading as _threading
+
+            class DummyThread(_threading.Thread):
                 def __init__(self, target=None, *a, **k):
-                    self.target = target
+                    self._target_name = target.__name__ if target else None
+                    super().__init__(target=target, *a, **k)
+
                 def start(self):
-                    started.append(self.target.__name__)
-            import threading
-            threading.Thread = lambda *a, **k: DummyThread(*a, **k)
+                    started.append(self._target_name)
+
+            _threading.Thread = DummyThread
             import app
             print('targets', started)
             """

--- a/tests/test_rtc_missing.py
+++ b/tests/test_rtc_missing.py
@@ -35,14 +35,18 @@ class RtcMissingTests(unittest.TestCase):
                 raise FileNotFoundError('missing bus')
             sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)
             started = []
-            class DummyThread:
+            import threading as _threading
+
+            class DummyThread(_threading.Thread):
                 def __init__(self, *a, **k):
+                    super().__init__(*a, **k)
                     self.started = False
+
                 def start(self):
                     self.started = True
                     started.append(True)
-            import threading
-            threading.Thread = lambda *a, **k: DummyThread()
+
+            _threading.Thread = DummyThread
             import app
             print('started', bool(started))
             print('bus_is_none', app.bus is None)


### PR DESCRIPTION
## Summary
- import APScheduler modules unconditionally
- always create a BackgroundScheduler instance
- adjust scheduler startup/shutdown logic
- update tests for new threading behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801300c4f08330962f6baa82746e96