### PR TITLE
Remove obsolete schedule stubs

### DIFF
--- a/tests/test_bt_monitor_thread.py
+++ b/tests/test_bt_monitor_thread.py
@@ -27,11 +27,6 @@ class BtMonitorThreadTests(unittest.TestCase):
                 )
             )
             sys.modules['pydub'] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
-            sys.modules['schedule'] = types.SimpleNamespace(
-                every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-                run_pending=lambda *a, **k: None,
-                clear=lambda *a, **k: None,
-            )
             def raise_fnf(*a, **k):
                 raise FileNotFoundError('missing bus')
             sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -33,11 +33,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -33,11 +33,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 

--- a/tests/test_missing_audio.py
+++ b/tests/test_missing_audio.py
@@ -40,11 +40,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_relay_invert.py
+++ b/tests/test_relay_invert.py
@@ -33,11 +33,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_rtc_missing.py
+++ b/tests/test_rtc_missing.py
@@ -26,11 +26,6 @@ class RtcMissingTests(unittest.TestCase):
                 )
             )
             sys.modules['pydub'] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
-            sys.modules['schedule'] = types.SimpleNamespace(
-                every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-                run_pending=lambda *a, **k: None,
-                clear=lambda *a, **k: None,
-            )
             def raise_fnf(*a, **k):
                 raise FileNotFoundError('missing bus')
             sys.modules['smbus'] = types.SimpleNamespace(SMBus=raise_fnf)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -47,11 +47,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_schedule_validation.py
+++ b/tests/test_schedule_validation.py
@@ -44,11 +44,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_set_time_no_rtc.py
+++ b/tests/test_set_time_no_rtc.py
@@ -33,11 +33,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -33,11 +33,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"

--- a/tests/test_wlan.py
+++ b/tests/test_wlan.py
@@ -32,11 +32,6 @@ sys.modules["smbus"] = types.SimpleNamespace(
     )
 )
 
-sys.modules["schedule"] = types.SimpleNamespace(
-    every=lambda *a, **k: types.SimpleNamespace(do=lambda *a, **k: None),
-    run_pending=lambda *a, **k: None,
-    clear=lambda *a, **k: None,
-)
 
 os.environ["FLASK_SECRET_KEY"] = "test"
 os.environ["TESTING"] = "1"


### PR DESCRIPTION
## Summary
- clean up `sys.modules["schedule"]` stubs from all tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880131e33c08330b2b06a2031efdf4a