### PR TITLE
Update README scheduling note

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 - **Passwort-Management**
 - **Alle Daten in SQLite-DB**
 - Einmalige Zeitpläne, deren Zeitpunkt bereits vergangen ist, werden beim Start automatisch übersprungen.
+- Zeitpläne laufen nun über **APScheduler**; dank `misfire_grace_time` werden nach dem Start keine verpassten Jobs mehr nachgeholt.
+- `parse_once_datetime` verarbeitet einmalige Zeitangaben in verschiedenen Formaten.
 
 ---
 


### PR DESCRIPTION
## Summary
- note that APScheduler handles schedules and missed jobs are skipped
- mention new `parse_once_datetime` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688012974f508330800062909544e0ef