### PR TITLE
Add XDG_RUNTIME_DIR to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ python app.py
 Service-Datei nutzt den Python-Interpreter aus der virtuellen Umgebung und
 startet das Programm mit PulseAudio-Zugriff (entweder über `User=pi` oder mit
 `PULSE_RUNTIME_PATH`). Durch `ExecStartPre=/bin/sleep 10` wartet der Dienst nach
-dem Booten zehn Sekunden, bevor `app.py` ausgeführt wird.
+dem Booten zehn Sekunden, bevor `app.py` ausgeführt wird. Zusätzlich setzt die
+Service-Datei `XDG_RUNTIME_DIR=/run/user/1000`, damit PulseAudio auch ohne
+laufende Sitzung funktioniert.
 
 Sollte die Unit manuell neu geladen werden müssen, genügt:
 ```bash

--- a/audio-pi.service
+++ b/audio-pi.service
@@ -8,6 +8,7 @@ WorkingDirectory=/opt/Audio-Pi-Websystem
 ExecStartPre=/bin/sleep 10
 Environment=FLASK_DEBUG=0
 Environment=FLASK_SECRET_KEY=
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 User=pi
 Group=audio
 ExecStart=/opt/Audio-Pi-Websystem/venv/bin/python /opt/Audio-Pi-Websystem/app.py


### PR DESCRIPTION
## Summary
- set `XDG_RUNTIME_DIR` in `audio-pi.service`
- document the environment variable in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f37522dc8330b6ff3df95b01815e