### PR TITLE
Unify schedule item selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -788,6 +788,7 @@ def set_relay_invert():
 @login_required
 def add_schedule():
     item_type = request.form["item_type"]
+    item_id = request.form["item_id"]
     time_str = request.form["time"]  # Erwarte Format YYYY-MM-DDTHH:MM
     repeat = request.form["repeat"]
     delay = int(request.form["delay"])
@@ -805,11 +806,7 @@ def add_schedule():
         flash("Ungültiges Datums-/Zeitformat")
         return redirect(url_for("index"))
 
-    if item_type == "file":
-        item_id = request.form["file_id"]
-    elif item_type == "playlist":
-        item_id = request.form["playlist_id"]
-    else:
+    if item_type not in ("file", "playlist"):
         flash("Ungültiger Typ ausgewählt")
         return redirect(url_for("index"))
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,22 +95,11 @@
 <section id="schedules">
     <h3>Zeitpläne</h3>
     <form action="{{ url_for('add_schedule') }}" method="POST">
-        <select name="item_type">
+        <select name="item_type" id="item-type">
             <option value="file">Datei</option>
             <option value="playlist">Playlist</option>
         </select>
-        <select name="file_id">
-            <option value="">-- Datei wählen --</option>
-            {% for file in files %}
-            <option value="{{ file[0] }}">{{ file[1] }}</option>
-            {% endfor %}
-        </select>
-        <select name="playlist_id">
-            <option value="">-- Playlist wählen --</option>
-            {% for playlist in playlists %}
-            <option value="{{ playlist[0] }}">{{ playlist[1] }}</option>
-            {% endfor %}
-        </select>
+        <select name="item_id" id="item-select"></select>
         <input type="datetime-local" name="time" required>
         <select name="repeat">
             <option value="daily">Täglich</option>
@@ -131,6 +120,26 @@
         </li>
         {% endfor %}
     </ul>
+
+    <script>
+    const files = {{ files | tojson }};
+    const playlists = {{ playlists | tojson }};
+    const itemSelect = document.getElementById('item-select');
+    const typeSelect = document.getElementById('item-type');
+    function populate() {
+        const items = typeSelect.value === 'playlist' ? playlists : files;
+        const label = typeSelect.value === 'playlist' ? 'Playlist' : 'Datei';
+        itemSelect.innerHTML = `<option value="">-- ${label} wählen --</option>`;
+        for (const item of items) {
+            const opt = document.createElement('option');
+            opt.value = item[0];
+            opt.textContent = item[1];
+            itemSelect.appendChild(opt);
+        }
+    }
+    typeSelect.addEventListener('change', populate);
+    populate();
+    </script>
 </section>
 
 <section id="system">

--- a/tests/test_schedule_validation.py
+++ b/tests/test_schedule_validation.py
@@ -84,8 +84,7 @@ class ScheduleValidationTests(unittest.TestCase):
                 method="POST",
                 data={
                     "item_type": "file",
-                    "file_id": "",
-                    "playlist_id": "",
+                    "item_id": "",
                     "time": "2024-01-01T10:00",
                     "repeat": "once",
                     "delay": "0",


### PR DESCRIPTION
## Summary
- simplify schedule form with single dropdown
- update add_schedule handler to read generic `item_id`
- fix schedule validation test for new form field

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810c619a248330a618e8dde8576356