### PR TITLE
Bluetooth-Buttons für Web-UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 
 - **Audio-Wiedergabe per Zeitplan** (Einzeldateien & Playlists)
 - **Bluetooth als Audio-Sink** (Handy → Pi → Verstärker)
+- **Bluetooth über Web-UI ein-/ausschalten**
 - **Endstufe/GPIO automatisch schalten** (bei Musik oder BT-Audio)
 - **Relais-Logik invertierbar über Web-UI**
 - **RTC-Steuerung & Systemzeit**
@@ -20,6 +21,9 @@ Audio-Pi-Control ist ein vollständiges Steuer- und Audiomanagement-System für 
 - Einmalige Zeitpläne, deren Zeitpunkt bereits vergangen ist, werden beim Start automatisch übersprungen.
 - Zeitpläne laufen nun über **APScheduler**; dank `misfire_grace_time` werden nach dem Start keine verpassten Jobs mehr nachgeholt.
 - `parse_once_datetime` verarbeitet einmalige Zeitangaben in verschiedenen Formaten.
+
+Im Bereich "System" der Weboberfläche befinden sich Buttons zum Ein- und
+Ausschalten von Bluetooth.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -991,6 +991,39 @@ def update():
     return redirect(url_for("index"))
 
 
+def enable_bluetooth():
+    subprocess.check_call(["sudo", "bluetoothctl", "power", "on"])
+    bluetooth_auto_accept()
+
+
+def disable_bluetooth():
+    subprocess.check_call(["sudo", "bluetoothctl", "power", "off"])
+
+
+@app.route("/bluetooth_on", methods=["POST"])
+@login_required
+def bluetooth_on():
+    try:
+        enable_bluetooth()
+        flash("Bluetooth aktiviert")
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Bluetooth einschalten fehlgeschlagen: {e}")
+        flash("Bluetooth konnte nicht aktiviert werden")
+    return redirect(url_for("index"))
+
+
+@app.route("/bluetooth_off", methods=["POST"])
+@login_required
+def bluetooth_off():
+    try:
+        disable_bluetooth()
+        flash("Bluetooth deaktiviert")
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Bluetooth ausschalten fehlgeschlagen: {e}")
+        flash("Bluetooth konnte nicht deaktiviert werden")
+    return redirect(url_for("index"))
+
+
 def bluetooth_auto_accept():
     p = subprocess.Popen(
         ["sudo", "bluetoothctl"],

--- a/templates/index.html
+++ b/templates/index.html
@@ -147,6 +147,12 @@
     <form action="{{ url_for('update') }}" method="POST">
         <button type="submit" class="btn">Update</button>
     </form>
+    <form action="{{ url_for('bluetooth_on') }}" method="POST" style="display:inline;">
+        <button type="submit" class="btn">Bluetooth an</button>
+    </form>
+    <form action="{{ url_for('bluetooth_off') }}" method="POST" style="display:inline;">
+        <button type="submit" class="btn">Bluetooth aus</button>
+    </form>
 </section>
 
 {% endblock %}

--- a/tests/test_bluetooth_toggle.py
+++ b/tests/test_bluetooth_toggle.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import sqlite3
+import types
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Fake modules required for app import
+sys.modules["lgpio"] = types.SimpleNamespace(
+    gpiochip_open=lambda *a, **k: 1,
+    gpio_claim_output=lambda *a, **k: None,
+    gpio_write=lambda *a, **k: None,
+    gpio_free=lambda *a, **k: None,
+    error=Exception,
+)
+
+sys.modules["pygame"] = types.SimpleNamespace(
+    mixer=types.SimpleNamespace(
+        init=lambda *a, **k: None,
+        music=types.SimpleNamespace(set_volume=lambda *a, **k: None),
+    )
+)
+
+sys.modules["pydub"] = types.SimpleNamespace(AudioSegment=types.SimpleNamespace())
+
+sys.modules["smbus"] = types.SimpleNamespace(
+    SMBus=lambda *a, **k: types.SimpleNamespace(
+        read_i2c_block_data=lambda *a, **k: [0] * 7,
+        write_i2c_block_data=lambda *a, **k: None,
+    )
+)
+
+os.environ["FLASK_SECRET_KEY"] = "test"
+os.environ["TESTING"] = "1"
+
+# Use in-memory SQLite during tests
+_orig_connect = sqlite3.connect
+
+def connect_memory(*args, **kwargs):
+    return _orig_connect(":memory:", check_same_thread=False)
+
+
+def dummy_popen(*args, **kwargs):
+    mock_proc = MagicMock()
+    mock_proc.communicate.return_value = ("", "")
+    return mock_proc
+
+
+with patch("sqlite3.connect", side_effect=connect_memory), patch(
+    "subprocess.getoutput", return_value="volume: 50%"
+), patch("subprocess.call"), patch("subprocess.Popen", dummy_popen):
+    import app
+    importlib.reload(app)
+
+
+class BluetoothToggleTests(unittest.TestCase):
+    def test_bluetooth_on_route(self):
+        with patch("app.subprocess.check_call") as call_mock, patch(
+            "app.bluetooth_auto_accept"
+        ) as auto_mock, patch("app.flash") as flash_mock, patch("app.redirect") as red_mock, patch(
+            "app.url_for", return_value="/"
+        ), patch(
+            "flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()
+        ):
+            with app.app.test_request_context("/bluetooth_on", method="POST"):
+                app.bluetooth_on()
+        call_mock.assert_any_call(["sudo", "bluetoothctl", "power", "on"])
+        auto_mock.assert_called_once()
+        red_mock.assert_called_with("/")
+        flash_mock.assert_called()
+
+    def test_bluetooth_off_route(self):
+        with patch("app.subprocess.check_call") as call_mock, patch(
+            "app.flash"
+        ) as flash_mock, patch("app.redirect") as red_mock, patch(
+            "app.url_for", return_value="/"
+        ), patch(
+            "flask_login.utils._get_user", return_value=type("U", (), {"is_authenticated": True})()
+        ):
+            with app.app.test_request_context("/bluetooth_off", method="POST"):
+                app.bluetooth_off()
+        call_mock.assert_any_call(["sudo", "bluetoothctl", "power", "off"])
+        red_mock.assert_called_with("/")
+        flash_mock.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `enable_bluetooth` und `disable_bluetooth`
- neue Routen `/bluetooth_on` und `/bluetooth_off`
- Buttons zum BT-Toggle in `index.html`
- Tests für die neuen Routen
- Dokumentation um Bluetooth-Schalter ergänzt

## Testing
- `python -m pip install -r requirements-dev.txt`
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688206d3b874833082428d0a853ac9eb