### PR TITLE
Add pytest tests for parse_once_datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Im Web-Interface gibt es einen **Update**-Button. Nach dem Login kann damit ein
 `git pull` ausgeführt werden, um lokale Änderungen aus dem Repository zu holen.
 Ein Hinweis informiert über Erfolg oder Fehler.
 
+## Tests
+
+Die Tests laufen mit `pytest`. Nachdem die Abhängigkeiten installiert sind,
+lassen sich alle Tests einfach per
+
+```bash
+pytest
+```
+ausführen.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydub==0.25.1
 smbus==1.1.post2
 APScheduler==3.10.4
 werkzeug==3.1.3
+pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+# Benötigte Umgebungsvariablen setzen
+os.environ.setdefault("FLASK_SECRET_KEY", "test")
+os.environ["TESTING"] = "1"
+
+# Sicherstellen, dass das Projektverzeichnis im Suchpfad liegt
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import parse_once_datetime
+import pytest
+
+
+def test_parse_iso_z():
+    dt = parse_once_datetime("2024-01-01T00:00:00Z")
+    assert dt == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_naive():
+    dt = parse_once_datetime("2024-02-02T12:30:45")
+    assert dt == datetime(2024, 2, 2, 12, 30, 45)
+
+
+def test_parse_space_seconds():
+    dt = parse_once_datetime("2024-03-03 08:15:30")
+    assert dt == datetime(2024, 3, 3, 8, 15, 30)
+
+
+def test_parse_space_minutes():
+    dt = parse_once_datetime("2024-04-04 09:20")
+    assert dt == datetime(2024, 4, 4, 9, 20)
+
+
+def test_parse_invalid():
+    with pytest.raises(ValueError):
+        parse_once_datetime("foo")


### PR DESCRIPTION
## Summary
- add minimal PyTest suite
- install pytest in requirements
- document how to run tests in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688558a70d68833082191327d0791571