### PR TITLE
Add Tests für Hilfsfunktionen und GitHub-Action

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        env:
+          FLASK_SECRET_KEY: dummy
+          TESTING: "1"
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydub==0.25.1
 smbus==1.1.post2
 APScheduler==3.10.4
 werkzeug==3.1.3
+pytest==8.4.1

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,43 @@
+import os
+import importlib
+
+# Vor dem Import Umgebungsvariablen setzen
+os.environ.setdefault('FLASK_SECRET_KEY', 'test')
+os.environ.setdefault('TESTING', '1')
+
+app = importlib.import_module('app')
+
+from app import validate_time, parse_once_datetime
+from datetime import datetime
+import pytest
+
+
+def test_validate_time_valid():
+    assert validate_time('00:00:00')
+    assert validate_time('23:59:59')
+
+
+def test_validate_time_invalid():
+    assert not validate_time('24:00:00')
+    assert not validate_time('12:00')
+    assert not validate_time('12:00:60')
+
+
+def test_parse_once_datetime_iso_z():
+    dt = parse_once_datetime('2024-05-13T12:30:45Z')
+    assert dt == datetime(2024, 5, 13, 12, 30, 45, tzinfo=dt.tzinfo)
+
+
+def test_parse_once_datetime_space_second():
+    dt = parse_once_datetime('2024-05-13 12:30:45')
+    assert dt == datetime(2024, 5, 13, 12, 30, 45)
+
+
+def test_parse_once_datetime_space_minute():
+    dt = parse_once_datetime('2024-05-13 12:30')
+    assert dt == datetime(2024, 5, 13, 12, 30)
+
+
+def test_parse_once_datetime_invalid():
+    with pytest.raises(ValueError):
+        parse_once_datetime('invalid')


### PR DESCRIPTION
## Zusammenfassung
- pytest in `requirements.txt` ergänzt
- Verzeichnis `tests/` mit Unittests für `validate_time` und `parse_once_datetime`
- GitHub Action hinzugefügt, die pytest bei jedem Commit ausführt

## Testanweisungen
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68855992869c8330a56b4e993d02b190