### PR TITLE
Fix Scheduler shutdown check

### DIFF
--- a/app.py
+++ b/app.py
@@ -1053,4 +1053,6 @@ if __name__ == "__main__":
     try:
         app.run(host="0.0.0.0", port=8080, debug=debug)
     finally:
-        scheduler.shutdown()
+        # Scheduler nur stoppen, wenn er wirklich gestartet wurde (z.B. nicht im TESTING-Modus)
+        if getattr(scheduler, "running", False):
+            scheduler.shutdown()

--- a/tests/test_scheduler_shutdown.py
+++ b/tests/test_scheduler_shutdown.py
@@ -1,0 +1,16 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def test_scheduler_shutdown_without_start():
+    env = os.environ.copy()
+    env['FLASK_SECRET_KEY'] = 'test'
+    env['TESTING'] = '1'
+    proc = subprocess.Popen([sys.executable, 'app.py'], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(1)
+    proc.send_signal(signal.SIGINT)
+    stdout, stderr = proc.communicate(timeout=5)
+    assert b'SchedulerNotRunningError' not in stderr


### PR DESCRIPTION
## Summary
- avoid shutting down non-started scheduler in `app.py`
- add regression test ensuring SchedulerNotRunningError is avoided when `TESTING=1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885597fb8e48330920c9b04a4052246