### PR TITLE
DB-Verbindung im Shutdown schließen

### DIFF
--- a/app.py
+++ b/app.py
@@ -1064,6 +1064,7 @@ if __name__ == "__main__":
         # Scheduler nur stoppen, wenn er wirklich gestartet wurde (z.B. nicht im TESTING-Modus)
         if getattr(scheduler, "running", False):
             scheduler.shutdown()
+            conn.close()
         if not TESTING and gpio_handle is not None:
             try:
                 deactivate_amplifier()


### PR DESCRIPTION
## Zusammenfassung
- DB-Verbindung wird im `finally`-Block von `app.py` geschlossen

## Testanweisungen
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885709dff308330a8c6cefbae9625eb