### PR TITLE
Upload-Verzeichnis bei Import anlegen

### DIFF
--- a/app.py
+++ b/app.py
@@ -1056,7 +1056,6 @@ if not TESTING:
     threading.Thread(target=bt_audio_monitor, daemon=True).start()
 
 if __name__ == "__main__":
-    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
     debug = os.environ.get("FLASK_DEBUG", "").lower() in ("1", "true", "yes")
     try:
         app.run(host="0.0.0.0", port=8080, debug=debug)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+def test_upload_dir_created_on_import(tmp_path):
+    env = os.environ.copy()
+    env['FLASK_SECRET_KEY'] = 'test'
+    env['TESTING'] = '1'
+    env['DB_FILE'] = str(tmp_path / 'test.db')
+    env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1])
+    subprocess.run([sys.executable, '-c', 'import app'], env=env, cwd=tmp_path, check=True)
+    assert (tmp_path / 'uploads').is_dir()
+


### PR DESCRIPTION
## Zusammenfassung
- entferne zweite `os.makedirs`-Aufruf im `__main__`-Block
- neuer Test stellt sicher, dass beim Import ein Upload-Verzeichnis entsteht

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688570a323e0833092f931cd52ff7217