### PR TITLE
Dok-Update: Hinweis auf Secret Key für Systemdienst

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python app.py
 
 ### Automatischer Start (systemd)
 
-`install.sh` kopiert und konfiguriert `audio-pi.service` automatisch. Die
+`install.sh` kopiert und konfiguriert `audio-pi.service` automatisch. Dabei wird der während der Installation abgefragte `FLASK_SECRET_KEY` eingetragen; ohne gültigen Schlüssel startet der Dienst nicht. Die
 Service-Datei nutzt den Python-Interpreter aus der virtuellen Umgebung und
 startet das Programm mit PulseAudio-Zugriff (entweder über `User=pi` oder mit
 `PULSE_RUNTIME_PATH`). Durch `ExecStartPre=/bin/sleep 10` wartet der Dienst nach


### PR DESCRIPTION
## Zusammenfassung
- README-Abschnitt zum systemd-Dienst erweitert
- Hinweis auf Pflicht zur Eintragung von `FLASK_SECRET_KEY`

## Testnachweis
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688570afa4088330aa74408cd67e502b