### PR TITLE
Handle legacy RTC timestamps without stored offset

### DIFF
--- a/app.py
+++ b/app.py
@@ -1181,8 +1181,21 @@ def read_rtc():
             weekday_raw,
             dt_value.weekday(),
         )
-    target_tz = LOCAL_TZ
     offset_minutes = _load_rtc_local_offset_minutes()
+    target_tz = LOCAL_TZ
+    if offset_minutes is None:
+        legacy_tz = target_tz
+        if legacy_tz is None:
+            try:
+                legacy_tz = datetime.now().astimezone().tzinfo
+            except Exception:  # pragma: no cover - Plattform ohne Zeitzoneninformationen
+                legacy_tz = None
+        if legacy_tz is not None:
+            dt_value = dt_value.replace(tzinfo=legacy_tz)
+        else:
+            logging.getLogger(__name__).debug(
+                "RTC-Wert ohne Offset-Einstellung, behalte UTC bei"
+            )
     if target_tz is None and offset_minutes is not None:
         target_tz = timezone(timedelta(minutes=offset_minutes))
     if target_tz is None:


### PR DESCRIPTION
## Summary
- interpret RTC register values as local time when the stored offset is missing to avoid misapplying the local offset on upgrade
- extend RTC status tests to cover the legacy fallback and adjust read/write cycle fixtures for the persisted offset

## Testing
- pytest tests/test_rtc_sync.py tests/test_rtc_status.py

------
https://chatgpt.com/codex/tasks/task_e_6900ec4746a483309629d84968dba513